### PR TITLE
Increment Task Id since all tasks have default Id of 0

### DIFF
--- a/TaskService/Controllers/TasksController.cs
+++ b/TaskService/Controllers/TasksController.cs
@@ -15,6 +15,7 @@ namespace TaskService.Controllers
         // In this service we're using an in-memory list to store tasks, just to keep things simple.
         // All of your tasks will be lost each time you run the service
         private static List<Models.Task> db = new List<Models.Task>();
+        private static int taskId;
 
         // OWIN auth middleware constants
         public const string scopeElement = "http://schemas.microsoft.com/identity/claims/scope";
@@ -46,6 +47,7 @@ namespace TaskService.Controllers
                 throw new WebException("Please provide a task description");
 
             string owner = ClaimsPrincipal.Current.FindFirst(objectIdElement).Value;
+            task.Id = taskId++;
             task.Owner = owner;
             task.Completed = false;
             task.DateModified = DateTime.UtcNow;


### PR DESCRIPTION
I noticed the Delete button will always remove the first task in the list no matter which delete button is clicked. This is caused by all tasks defaulting to an Id = 0.

This pull requests adds a simple static int to increment when adding Tasks on POST to set a unique Id. With this change the Delete button will remove the task associated with the button.