### PR TITLE
Issue #39 - add error handling and verbosity around claims matching

### DIFF
--- a/TaskWebApp/Controllers/TasksController.cs
+++ b/TaskWebApp/Controllers/TasksController.cs
@@ -56,7 +56,7 @@ namespace TaskWebApp.Controllers
                     case HttpStatusCode.Unauthorized:
                         return ErrorAction("Please sign in again. " + response.ReasonPhrase);
                     default:
-                        return ErrorAction("Error. Status code = " + response.StatusCode);
+                        return ErrorAction("Error. Status code = " + response.StatusCode + ": " + response.ReasonPhrase);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Slightly better error handling around claims - this makes it more obvious if you have a claims mis-match, for someone who is new to oauth2 like me :)