### PR TITLE
Update startup.Auth.cs

### DIFF
--- a/TaskWebApp/App_Start/Startup.Auth.cs
+++ b/TaskWebApp/App_Start/Startup.Auth.cs
@@ -49,6 +49,9 @@ namespace TaskWebApp
         */
         public void ConfigureAuth(IAppBuilder app)
         {
+            // Required for Azure webapps, as by default they force TLS 1.2 and this project attempts 1.0
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
 
             app.UseCookieAuthentication(new CookieAuthenticationOptions());


### PR DESCRIPTION
Fix issue when deploying to Azure. By default, webapps force TLS1.2 whereas the webapp client by default negotiates with 1.0 only.