### PR TITLE
Fixed swapped cache methods

### DIFF
--- a/TaskWebApp/Utils/MSALPerUserSessionTokenCache.cs
+++ b/TaskWebApp/Utils/MSALPerUserSessionTokenCache.cs
@@ -178,7 +178,11 @@ namespace TaskWebApp.Utils
 		/// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
 		private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
 		{
-			this.LoadUserTokenCacheFromSession();
+			// if the access operation resulted in a cache update
+			if (args.HasStateChanged)
+			{
+				this.PersistUserTokenCache();
+			}
 		}
 
 		/// <summary>
@@ -187,11 +191,7 @@ namespace TaskWebApp.Utils
 		/// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
 		private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
 		{
-			// if the access operation resulted in a cache update
-			if (args.HasStateChanged)
-			{
-				this.PersistUserTokenCache();
-			}
+			this.LoadUserTokenCacheFromSession();
 		}
 
 		/// <summary>


### PR DESCRIPTION
As an urgent hotfix, I have fixed UserTokenCacheAfterAccessNotification and UserTokenCacheBeforeAccessNotification swapped implementations.

Jean-Marc suggested to improve our .NET 4.X cache providers according to the latest changes on microsoft-authentication-extensions-for-dotnet but since this will require more time, I would like to do this quick hotfix first to prevent developers of cloning a wrong class as soon as possible.
