### PR TITLE
Enable sign-out and tasks for all tenants

### DIFF
--- a/TaskService/Controllers/TasksController.cs
+++ b/TaskService/Controllers/TasksController.cs
@@ -33,7 +33,7 @@ namespace TaskService.Controllers
         {
             HasRequiredScopes(ReadPermission);
 
-            var owner = CheckClaimMatch(objectIdElement);
+            var owner = CheckClaimMatch(ClaimTypes.NameIdentifier);
 
             IEnumerable<Models.Task> userTasks = db.Where(t => t.Owner == owner);
             return userTasks;
@@ -49,7 +49,7 @@ namespace TaskService.Controllers
             if (String.IsNullOrEmpty(task.Text))
                 throw new WebException("Please provide a task description");
 
-            var owner = CheckClaimMatch(objectIdElement);
+            var owner = CheckClaimMatch(ClaimTypes.NameIdentifier);
 
             task.Id = taskId++;
             task.Owner = owner;
@@ -65,7 +65,7 @@ namespace TaskService.Controllers
         {
             HasRequiredScopes(WritePermission);
 
-            var owner = CheckClaimMatch(objectIdElement);
+            var owner = CheckClaimMatch(ClaimTypes.NameIdentifier);
 
             Models.Task task = db.Where(t => t.Owner.Equals(owner) && t.Id.Equals(id)).FirstOrDefault();
             db.Remove(task);

--- a/TaskWebApp/Utils/ClaimsPrincipalExtension.cs
+++ b/TaskWebApp/Utils/ClaimsPrincipalExtension.cs
@@ -54,11 +54,11 @@ namespace TaskWebApp.Utils
 		/// <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found</returns>
 		public static string GetObjectId(this ClaimsPrincipal claimsPrincipal)
         {
-            var objIdclaim = claimsPrincipal.FindFirst(ClaimConstants.ObjectId);
+            var objIdclaim = claimsPrincipal.FindFirst(ClaimTypes.NameIdentifier);
 
             if (objIdclaim == null)
             {
-                objIdclaim = claimsPrincipal.FindFirst("oid");
+                objIdclaim = claimsPrincipal.FindFirst("sub");
             }
 
             return objIdclaim != null ? objIdclaim.Value : string.Empty;


### PR DESCRIPTION
This enables both **sign-out** and **task list** functionality when using a tenant in one's own B2C directory *or* the demo `fabrikamb2c` tenant.

The sample currently functions out of the box using the demo tenant, `fabrikamb2c`, but if one follows these B2C tutorials to configure it for their own B2C tenant, neither sign-out nor the task list work correctly:

* [Tutorial: Enable authentication in a web application using Azure Active Directory B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-tutorials-web-app)
* [Tutorial: Grant access to an ASP.NET web API using Azure Active Directory B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-tutorials-web-api)

There is also a follow-up update I'll be making to the API doc as it's missing a needed modification to the TaskService/Web.config (addresses the busted To-Do portion of https://github.com/MicrosoftDocs/azure-docs/issues/38447).

Cc: @jennyf19 @yoelhor 