### PR TITLE
Forced B2C policy names to lower-case to ensure accounts are found

### DIFF
--- a/TaskWebApp/Utils/Globals.cs
+++ b/TaskWebApp/Utils/Globals.cs
@@ -14,9 +14,9 @@ namespace TaskWebApp.Utils
         public static string ServiceUrl = ConfigurationManager.AppSettings["api:TaskServiceUrl"];
 
         // B2C policy identifiers
-        public static string SignUpSignInPolicyId = ConfigurationManager.AppSettings["ida:SignUpSignInPolicyId"];
-        public static string EditProfilePolicyId = ConfigurationManager.AppSettings["ida:EditProfilePolicyId"];
-        public static string ResetPasswordPolicyId = ConfigurationManager.AppSettings["ida:ResetPasswordPolicyId"];
+        public static string SignUpSignInPolicyId = ConfigurationManager.AppSettings["ida:SignUpSignInPolicyId"].ToLower();
+        public static string EditProfilePolicyId = ConfigurationManager.AppSettings["ida:EditProfilePolicyId"].ToLower();
+        public static string ResetPasswordPolicyId = ConfigurationManager.AppSettings["ida:ResetPasswordPolicyId"].ToLower();
 
         public static string DefaultPolicy = SignUpSignInPolicyId;
 

--- a/TaskWebApp/Web.config
+++ b/TaskWebApp/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301880

--- a/TaskWebApp/Web.config
+++ b/TaskWebApp/Web.config
@@ -189,11 +189,12 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<system.webServer>
+  <system.webServer>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
-  </system.webServer></configuration>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Merging #119

Forced B2C policy names to lower-case to ensure accounts are founden calling IConfidentialClientApp.GetAccountAsync(string identifier). (#119)